### PR TITLE
batch size option for all loop method

### DIFF
--- a/lib/dotloop/loop.rb
+++ b/lib/dotloop/loop.rb
@@ -52,7 +52,7 @@ module Dotloop
     end
 
     def all(options = {})
-      raise 'invalid batch size provided, allowed values minimum 1 and maximum 100' if invalid_batch_size?(options)
+      raise_if_invalid_batch_size(options)
       options[:batch_size] ||= BATCH_SIZE
       Array.new.tap do |arr|
         (1..MAX_LOOPS).each do |i|
@@ -145,8 +145,8 @@ module Dotloop
 
     private
 
-    def invalid_batch_size?(options)
-      !options[:batch_size].nil? && (options[:batch_size] < 1 || options[:batch_size] > 100)
+    def raise_if_invalid_batch_size(options)
+      raise 'invalid batch size provided, allowed values minimum 1 and maximum 100' if !options[:batch_size].nil? && (options[:batch_size] < 1 || options[:batch_size] > 100)
     end
 
     def query_params(options)

--- a/lib/dotloop/loop.rb
+++ b/lib/dotloop/loop.rb
@@ -52,16 +52,16 @@ module Dotloop
     end
 
     def all(options = {})
-      loops = []
       raise 'invalid batch size provided, allowed values minimum 1 and maximum 100' if !options[:batch_size].nil? && (options[:batch_size] < 1 || options[:batch_size] > 100)
       options[:batch_size] ||= BATCH_SIZE
-      (1..MAX_LOOPS).each do |i|
-        options[:batch_number] = i
-        current_batch = batch(options)
-        loops += current_batch
-        break if current_batch.size < options[:batch_size]
-      end
-      loops
+      Array.new.tap do |arr|
+        (1..MAX_LOOPS).each do |i|
+          options[:batch_number] = i
+          current_batch = batch(options)
+          arr.push current_batch
+          break if current_batch.size < options[:batch_size]
+        end
+      end.flatten
     end
 
     def batch(options = {})

--- a/lib/dotloop/loop.rb
+++ b/lib/dotloop/loop.rb
@@ -53,7 +53,8 @@ module Dotloop
 
     def all(options = {})
       loops = []
-      options[:batch_size] = BATCH_SIZE
+      raise 'invalid batch size provided, allowed values minimum 1 and maximum 100' if !options[:batch_size].nil? && (options[:batch_size] < 1 || options[:batch_size] > 100)
+      options[:batch_size] ||= BATCH_SIZE
       (1..MAX_LOOPS).each do |i|
         options[:batch_number] = i
         current_batch = batch(options)

--- a/lib/dotloop/loop.rb
+++ b/lib/dotloop/loop.rb
@@ -52,7 +52,7 @@ module Dotloop
     end
 
     def all(options = {})
-      raise 'invalid batch size provided, allowed values minimum 1 and maximum 100' if !options[:batch_size].nil? && (options[:batch_size] < 1 || options[:batch_size] > 100)
+      raise 'invalid batch size provided, allowed values minimum 1 and maximum 100' if invalid_batch_size?(options)
       options[:batch_size] ||= BATCH_SIZE
       Array.new.tap do |arr|
         (1..MAX_LOOPS).each do |i|
@@ -144,6 +144,10 @@ module Dotloop
     end
 
     private
+
+    def invalid_batch_size?(options)
+      !options[:batch_size].nil? && (options[:batch_size] < 1 || options[:batch_size] > 100)
+    end
 
     def query_params(options)
       {

--- a/spec/dotloop/loop_spec.rb
+++ b/spec/dotloop/loop_spec.rb
@@ -15,6 +15,19 @@ describe Dotloop::Loop do
   end
 
   describe '#all' do
+    it 'return all loops - rejects invalid batch size' do
+      dotloop_mock_batch(:loops)
+      expect {
+        subject.all(profile_id: '1234', batch_size: 500)
+      }.to raise_error("invalid batch size provided, allowed values minimum 1 and maximum 100")
+    end
+
+    it 'return loops - using a batch size params' do
+      dotloop_mock_batch(:loops)
+      expect(subject).to receive(:batch).once.and_call_original
+      loops = subject.all(profile_id: '1234', batch_size: 100)
+    end
+
     it 'return all loops' do
       dotloop_mock_batch(:loops)
       expect(subject).to receive(:batch).twice.and_call_original

--- a/spec/dotloop/loop_spec.rb
+++ b/spec/dotloop/loop_spec.rb
@@ -15,7 +15,7 @@ describe Dotloop::Loop do
   end
 
   describe '#all' do
-    it 'return all loops - rejects invalid batch size' do
+    it 'rejects when invalid batch size, allows batch_size > 0 and <= 100' do
       dotloop_mock_batch(:loops)
       expect {
         subject.all(profile_id: '1234', batch_size: 500)


### PR DESCRIPTION
- allowed an option to provide batch size.
- raises exception if batch size is less than 1 or more than 500.