### PR TITLE
Add deactivated flag to profile - To know whether profile is active/inactive

### DIFF
--- a/lib/dotloop/models/profile.rb
+++ b/lib/dotloop/models/profile.rb
@@ -8,6 +8,7 @@ module Dotloop
       attribute :address
       attribute :city
       attribute :company
+      attribute :deactivated, Boolean
       attribute :default, Boolean
       attribute :fax
       attribute :id, Integer


### PR DESCRIPTION
> We have done the integration with dotloop. Currently, in our app, we show all the dotloop profiles available in account including "Inactive" as well as profiles which user don't have access as API return all the profiles. Is there any way to list the only active profiles?

> We are using following api to list profiles. 
https://dotloop.github.io/public-api/#list-all-profiles

I would ignore any profiles that have a parameter of “deactivated: true”.  That should ensure you are only showing the user the profiles they have active.