### PR TITLE
Move runtime dependency to development dependency

### DIFF
--- a/dotloop-ruby.gemspec
+++ b/dotloop-ruby.gemspec
@@ -30,14 +30,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'simplecov'
-  spec.add_runtime_dependency 'coveralls'
   spec.add_runtime_dependency 'httparty', '~> 0.13'
   spec.add_runtime_dependency 'virtus', '~> 1.0'
   spec.add_runtime_dependency 'plissken', '~> 0.2'
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'pry', '~> 0.10'
   spec.add_development_dependency 'byebug', '~> 9.0'
   spec.add_development_dependency 'rubocop', '~> 0.49.0'


### PR DESCRIPTION
Move `simplecov` & `coveralls` gems from `runtime dependency` to `development dependency`